### PR TITLE
Add Lucide icons and localization

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -98,25 +98,46 @@
             background: var(--light-bg);
         }
         
+        .feature-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 30px;
+        }
+
         .feature-card {
             background: var(--card-bg);
             color: var(--text-color);
             border-radius: 15px;
             padding: 30px;
-            margin-bottom: 30px;
             box-shadow: 0 5px 15px rgba(0,0,0,0.2);
             transition: all 0.3s ease;
         }
-        
+
         .feature-card:hover {
             transform: translateY(-10px);
             box-shadow: 0 15px 30px rgba(0,0,0,0.2);
         }
-        
+
         .feature-icon {
-            font-size: 2.5rem;
-            color: var(--accent-color);
+            width: 60px;
+            height: 60px;
+            border-radius: 50%;
+            border: 2px solid var(--accent-color);
+            display: flex;
+            align-items: center;
+            justify-content: center;
             margin-bottom: 20px;
+            transition: transform 0.3s ease;
+        }
+
+        .feature-icon svg {
+            width: 32px;
+            height: 32px;
+            stroke-width: 1.5;
+        }
+
+        .feature-card:hover .feature-icon {
+            transform: scale(1.1);
         }
         
         .section-title {
@@ -595,9 +616,10 @@
             </li>
           </ul>
           <a href="#propertySearchForm" class="btn" style="background-color: #F6D984; color: #2c3e50; font-weight: 600; padding: 8px 22px; border-radius: 18px; margin-left: 18px; transition: all 0.3s; font-size: 1rem; display: inline-block;">Search</a>
+          <button id="langToggle" class="btn btn-sm btn-outline-light ms-3">عربي</button>
         </div>
-      </div>
-    </nav>
+        </div>
+      </nav>
 
     <!-- Hero Section -->
     <section class="hero-section">
@@ -624,48 +646,8 @@
     <section class="features-section">
         <div class="container">
             <h2 class="section-title">Why Choose Our Salesforce Solutions?</h2>
-            <div class="row">
-                <div class="col-md-4">
-                    <div class="feature-card">
-                        <div class="feature-icon">📊</div>
-                        <h3>Streamlined Operations</h3>
-                        <p>Automate property management, lead tracking, and deal processing with our integrated Salesforce solutions.</p>
-                        <div class="progress-area">
-                            <div class="progress">
-                                <div class="progress-fill" data-target="35"></div>
-                            </div>
-                            <span class="progress-num" data-target="35">0%</span>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-4">
-                    <div class="feature-card">
-                        <div class="feature-icon">🤝</div>
-                        <h3>Enhanced Client Relationships</h3>
-                        <p>Build stronger connections with clients through personalized communication and efficient service delivery.</p>
-                        <div class="progress-area">
-                            <div class="progress">
-                                <div class="progress-fill" data-target="45"></div>
-                            </div>
-                            <span class="progress-num" data-target="45">0%</span>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-4">
-                    <div class="feature-card">
-                        <div class="feature-icon">📈</div>
-                        <h3>Data-Driven Insights</h3>
-                        <p>Make informed decisions with real-time analytics and comprehensive reporting tools.</p>
-                        <div class="progress-area">
-                            <div class="progress">
-                                <div class="progress-fill" data-target="50"></div>
-                            </div>
-                            <span class="progress-num" data-target="50">0%</span>
-                        </div>
-                    </div>
-          </div>
+            <div id="features" class="feature-grid"></div>
         </div>
-      </div>
     </section>
 
     <!-- Search Section -->
@@ -835,10 +817,11 @@
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <!-- Toastify JS -->
-    <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
-    <!-- Custom JS -->
-    <script src="script.js"></script>
+      <!-- Toastify JS -->
+      <script src="https://cdn.jsdelivr.net/npm/toastify-js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/lucide@latest"></script>
+      <!-- Custom JS -->
+      <script src="script.js"></script>
     <script>
       // On page load, scroll to top (3Js Canvas) unless there is a hash in the URL
       window.addEventListener('DOMContentLoaded', function() {

--- a/public/script.js
+++ b/public/script.js
@@ -1066,13 +1066,12 @@ document.addEventListener('DOMContentLoaded', function () {
 // --- END: Desktop Switch Logic ---
 
 // --- BEGIN: Feature Progress Animation ---
-document.addEventListener('DOMContentLoaded', () => {
+function animateFeatureProgress() {
   const fills = document.querySelectorAll('.progress-fill');
   const nums = document.querySelectorAll('.progress-num');
 
   fills.forEach(fill => {
     const target = parseInt(fill.dataset.target, 10) || 0;
-    // trigger width animation after slight delay
     setTimeout(() => {
       fill.style.width = `${target}%`;
     }, 500);
@@ -1091,5 +1090,95 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     step();
   });
+}
+
+// --- BEGIN: Feature Cards & Localization ---
+document.addEventListener('DOMContentLoaded', () => {
+  const translations = {
+    en: {
+      toggle: 'عربي',
+      features: [
+        {
+          icon: 'bar-chart-2',
+          title: 'Streamlined Operations',
+          description: 'Automate property management, lead tracking, and deal processing with our integrated Salesforce solutions.',
+          percentage: 35
+        },
+        {
+          icon: 'handshake',
+          title: 'Enhanced Client Relationships',
+          description: 'Build stronger connections with clients through personalized communication and efficient service delivery.',
+          percentage: 45
+        },
+        {
+          icon: 'trending-up',
+          title: 'Data-Driven Insights',
+          description: 'Make informed decisions with real-time analytics and comprehensive reporting tools.',
+          percentage: 50
+        }
+      ]
+    },
+    ar: {
+      toggle: 'English',
+      features: [
+        {
+          icon: 'bar-chart-2',
+          title: 'عمليات سلسة',
+          description: 'قم بأتمتة إدارة العقارات وتتبع العملاء وإتمام الصفقات من خلال حلولنا المتكاملة من Salesforce.',
+          percentage: 35
+        },
+        {
+          icon: 'handshake',
+          title: 'علاقات عملاء أفضل',
+          description: 'ابنِ علاقات أقوى مع العملاء من خلال التواصل المخصص وتقديم الخدمة بكفاءة.',
+          percentage: 45
+        },
+        {
+          icon: 'trending-up',
+          title: 'رؤى قائمة على البيانات',
+          description: 'اتخذ قرارات مبنية على بيانات فورية وتقارير شاملة.',
+          percentage: 50
+        }
+      ]
+    }
+  };
+
+  const featuresContainer = document.getElementById('features');
+  const langToggle = document.getElementById('langToggle');
+  let currentLang = 'en';
+
+  function createFeatureCard({ icon, title, description, percentage }) {
+    const card = document.createElement('div');
+    card.className = 'feature-card';
+    card.innerHTML = `
+      <div class="feature-icon"><i data-lucide="${icon}" aria-label="${title}"></i></div>
+      <h3>${title}</h3>
+      <p>${description}</p>
+      <div class="progress-area">
+        <div class="progress"><div class="progress-fill" data-target="${percentage}"></div></div>
+        <span class="progress-num" data-target="${percentage}">0%</span>
+      </div>
+    `;
+    return card;
+  }
+
+  function renderFeatures() {
+    featuresContainer.innerHTML = '';
+    translations[currentLang].features.forEach(f => {
+      featuresContainer.appendChild(createFeatureCard(f));
+    });
+    lucide.createIcons();
+    animateFeatureProgress();
+  }
+
+  langToggle.addEventListener('click', () => {
+    currentLang = currentLang === 'en' ? 'ar' : 'en';
+    langToggle.textContent = translations[currentLang].toggle;
+    renderFeatures();
+  });
+
+  langToggle.textContent = translations[currentLang].toggle;
+  renderFeatures();
 });
+// --- END: Feature Cards & Localization ---
 // --- END: Feature Progress Animation ---


### PR DESCRIPTION
## Summary
- swap emoji icons for Lucide SVGs
- add language toggle and feature card rendering
- animate icons and use responsive grid layout

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686ce4c6301c8328af9f807d34c70799